### PR TITLE
fix import logrus to be compatible with go module

### DIFF
--- a/http.go
+++ b/http.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	ex "github.com/wolvex/go/error"
 )
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19160824/95309770-c4df3f80-08b5-11eb-815c-8ac8bbd8e4d7.png)

the issue is that go get in go module looks for package name case-sensitively, so the import path should follow its declared package name in its go.mod:

![image](https://user-images.githubusercontent.com/19160824/95310133-3dde9700-08b6-11eb-80c5-894f56d18765.png)
